### PR TITLE
Extended IProblem interface to make Graph information available

### DIFF
--- a/TspLibNet/TspLibNet/IProblem.cs
+++ b/TspLibNet/TspLibNet/IProblem.cs
@@ -23,6 +23,10 @@
 
 namespace TspLibNet
 {
+    using Graph.Edges;
+    using Graph.EdgeWeights;
+    using Graph.FixedEdges;
+    using Graph.Nodes;
     using Tours;
 
     /// <summary>
@@ -72,5 +76,25 @@ namespace TspLibNet
         /// <param name="tour">Tour to check</param>
         /// <returns>Tour distance</returns>
         double TourDistance(ITour tour);
+
+        /// <summary>
+        /// Gets nodes provider
+        /// </summary>
+        INodeProvider NodeProvider { get; }
+
+        /// <summary>
+        /// Gets Edges provider
+        /// </summary>
+        IEdgeProvider EdgeProvider { get; }
+
+        /// <summary>
+        /// Gets Edge Weights Provider
+        /// </summary>
+        IEdgeWeightsProvider EdgeWeightsProvider { get; }
+
+        /// <summary>
+        /// Gets Fixed Edges Provider
+        /// </summary>
+        IFixedEdgesProvider FixedEdgesProvider { get; }
     }
 }

--- a/TspLibNet/TspLibNet/ProblemBase.cs
+++ b/TspLibNet/TspLibNet/ProblemBase.cs
@@ -83,39 +83,39 @@ namespace TspLibNet
         }
 
         /// <summary>
-        /// Gets nodes provider
-        /// </summary>
-        public INodeProvider NodeProvider { get; protected set; }
-
-        /// <summary>
-        /// Gets Edges provider
-        /// </summary>
-        public IEdgeProvider EdgeProvider { get; protected set; }
-
-        /// <summary>
-        /// Gets Edge Weights Provider
-        /// </summary>
-        public IEdgeWeightsProvider EdgeWeightsProvider { get; protected set; }
-
-        /// <summary>
-        /// Gets Fixed Edges Provider
-        /// </summary>
-        public IFixedEdgesProvider FixedEdgesProvider { get; protected set; }
-
-        /// <summary>
         /// Represents the problem type (TSP, ATSP, etc).
         /// </summary>
-        public ProblemType Type { get; protected set; }
+        public ProblemType Type { get; }
 
         /// <summary>
         /// Gets file name - Identifies the data file.
         /// </summary>
-        public string Name { get; protected set; }
+        public string Name { get; }
 
         /// <summary>
         /// Gets file comment - additional comments from problem author
         /// </summary>
-        public string Comment { get; protected set; }
+        public string Comment { get; }
+
+        /// <summary>
+        /// Gets nodes provider
+        /// </summary>
+        public INodeProvider NodeProvider { get; }
+
+        /// <summary>
+        /// Gets Edges provider
+        /// </summary>
+        public IEdgeProvider EdgeProvider { get; }
+
+        /// <summary>
+        /// Gets Edge Weights Provider
+        /// </summary>
+        public IEdgeWeightsProvider EdgeWeightsProvider { get; }
+
+        /// <summary>
+        /// Gets Fixed Edges Provider
+        /// </summary>
+        public IFixedEdgesProvider FixedEdgesProvider { get; }
 
         /// <summary>
         /// Gets tour distance for a given problem


### PR DESCRIPTION
Reasoning: A user of the library creates a TspLib95 instance, loads some problems, gets hold of a
TspLib95Item for a specific TSP problem by name or problem type and, through it, only has access to IProblem via the Problem property.  

In order to apply his/her own algorithm to the TSP problem instance and construct a solution tour for it, he/she needs access to the underlying graph information, hence the extension.

Extending the interface is a nice, clean, abstract solution to the alternative of instantiating instances of problem-specific classes and since ALL the problem types already inherit from ProblemBase and ProblemBase already had these properties available, I considered this to be the most elegant solution available.
